### PR TITLE
Add tool to close backgrounded processes

### DIFF
--- a/src/tools/executor-tool.js
+++ b/src/tools/executor-tool.js
@@ -364,3 +364,30 @@ export function getProcessStatus(processId) {
     running: true
   };
 }
+
+export function closeProcess(processId) {
+  const proc = activeProcesses.get(processId);
+  if (!proc) return { error: 'Process not found', processId };
+
+  try {
+    if (proc.child && !proc.child.killed) {
+      proc.child.kill('SIGTERM');
+      setTimeout(() => {
+        if (proc.child && !proc.child.killed) {
+          proc.child.kill('SIGKILL');
+        }
+      }, 5000);
+    }
+    activeProcesses.delete(processId);
+    return {
+      success: true,
+      processId,
+      message: `Process ${processId} terminated`
+    };
+  } catch (error) {
+    return {
+      error: `Failed to close process: ${error?.message || String(error)}`,
+      processId
+    };
+  }
+}


### PR DESCRIPTION
Adds a new tool that allows closing and terminating backgrounded processes:
- Adds closeProcess function to executor-tool.js to kill processes and remove from tracking
- Creates process_close tool in index.js with input validation
- Handles SIGTERM followed by SIGKILL for robust process termination
- Returns success status or error information for closed processes